### PR TITLE
Add: Discord Sender 추가

### DIFF
--- a/src/main/java/com/knu/noticesender/config/CategoryUrlMapper.java
+++ b/src/main/java/com/knu/noticesender/config/CategoryUrlMapper.java
@@ -1,0 +1,16 @@
+package com.knu.noticesender.config;
+
+import com.knu.noticesender.notice.model.Category;
+import java.util.Map;
+
+public class CategoryUrlMapper {
+    private final Map<Category, String> urls;
+
+    CategoryUrlMapper(Map<Category, String> urls) {
+        this.urls = urls;
+    }
+
+    public String getUrl(Category category) {
+        return urls.get(category);
+    }
+}

--- a/src/main/java/com/knu/noticesender/config/DiscordConfig.java
+++ b/src/main/java/com/knu/noticesender/config/DiscordConfig.java
@@ -1,0 +1,23 @@
+package com.knu.noticesender.config;
+
+import com.knu.noticesender.notice.model.Category;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DiscordConfig {
+
+    //TODO("Discord Webhooks URL 추가 필요")
+    @Value("${discord.urls.all}")
+    private String all;
+
+    @Bean
+    public CategoryUrlMapper categoryURLMapper() {
+        Map<Category, String> urls = new HashMap<>();
+        urls.put(Category.ALL, all);
+        return new CategoryUrlMapper(urls);
+    }
+}

--- a/src/main/java/com/knu/noticesender/notice/NoticeDiscordSender.java
+++ b/src/main/java/com/knu/noticesender/notice/NoticeDiscordSender.java
@@ -1,0 +1,51 @@
+package com.knu.noticesender.notice;
+
+import java.util.Map;
+import java.util.HashMap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import com.knu.noticesender.notice.dto.NoticeDto;
+import org.springframework.web.client.RestTemplate;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.knu.noticesender.config.CategoryUrlMapper;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeDiscordSender implements NoticeSender{
+
+    private final ObjectMapper objectMapper;
+    private final CategoryUrlMapper categoryUrlMapper;
+
+    @Override
+    public void send(NoticeDto dto) {
+        RestTemplate rest = new RestTemplate();
+        HttpEntity<String> request = new HttpEntity<>(createSendBody(dto), createSendHeaders());
+        String url = categoryUrlMapper.getUrl(dto.getCategory());
+        rest.postForEntity(url, request, Object.class);
+    }
+
+    private HttpHeaders createSendHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
+
+    private String createSendBody(NoticeDto dto) {
+        Map<String, String> body = new HashMap<>();
+        body.put("username", "Server");
+        body.put("content", dto.convertToDiscordMessage());
+        return convertToJson(body);
+    }
+
+    private String convertToJson(Object body) {
+        try {
+            return objectMapper.writeValueAsString(body);
+        } catch (Exception e) {
+            //TODO("Error Code 수정")
+            throw new RuntimeException("데이터 변환 오류");
+        }
+    }
+}

--- a/src/main/java/com/knu/noticesender/notice/dto/NoticeDto.java
+++ b/src/main/java/com/knu/noticesender/notice/dto/NoticeDto.java
@@ -1,21 +1,39 @@
 package com.knu.noticesender.notice.dto;
 
 import com.knu.noticesender.notice.model.Category;
+import com.knu.noticesender.notice.model.NoticeType;
 import java.time.LocalDateTime;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
 public class NoticeDto {
-
+    @NotNull
     private Long num;
+
+    @NotNull
+    private Category category;
+
+    @NotNull
+    private NoticeType type;
 
     private String link;
 
     private String title;
 
-    private Category category;
-
     private String content;
 
     private LocalDateTime createdDate;
+
+    public String convertToDiscordMessage() {
+        //TODO("디스코드 메시지 양식")
+        switch (this.type) {
+            case NEW: break;
+            case UPDATE: break;
+            case OLD: break;
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
## Description

공지사항을 디스코드 서버로 전송합니다.

데이터베이스에 존재하는 공지사항 데이터를 통해

1. 공지사항 카테고리마다 별도의 채널로 공지사항 전송
2. 추후 메시지 발송 여부, 게시글 수정 여부에 따라서 기능 추가 고려

## Changes

NoticeDiscordSender: HTTP 통해 타겟 URL 에 메시지 전송

NoticeDto: 발송할 Notice 데이터 저장 Notice 타입 별 메시지 반환

CategoryUrlMapper: Category 별 URL 쌍 저장

## Test Checklist
