### PR TITLE
Enum Class Converter 추가

### DIFF
--- a/src/main/java/com/knu/noticesender/notice/model/Category.java
+++ b/src/main/java/com/knu/noticesender/notice/model/Category.java
@@ -1,23 +1,25 @@
 package com.knu.noticesender.notice.model;
 
 
-/**
- *     ALL: 전체
- *     NORMAL: 일반
- *     STUDENT: 학사
- *     SCHOLARSHIP: 장학
- *     SIM_COM: 심컴
- *     GL_SOP: 글솝
- *     GRADUATE_SCHOOL: 대학원
- *     GRADUATE_CONTRACT: 대학원 계약학과
- */
-public enum Category {
-    ALL,
-    NORMAL,
-    STUDENT,
-    SCHOLARSHIP,
-    SIM_COM,
-    GL_SOP,
-    GRADUATE_SCHOOL,
-    GRADUATE_CONTRACT
+public enum Category implements Convertible {
+    ALL("", "전체"),
+    NORMAL("", "일반"),
+    STUDENT("", "학사"),
+    SCHOLARSHIP("", "장학"),
+    SIM_COM("", "심컴"),
+    GL_SOP("", "글솝"),
+    GRADUATE_SCHOOL("", "대학원"),
+    GRADUATE_CONTRACT("", "대학원 계약학과");
+
+    private final String dbData;
+    private final String desc;
+
+    Category (String dbData, String desc) {
+        this.dbData = dbData;
+        this.desc = desc;
+    }
+
+    @Override
+    public String getDbData() {return dbData;}
+    public String getDesc() {return this.desc;}
 }

--- a/src/main/java/com/knu/noticesender/notice/model/Convertible.java
+++ b/src/main/java/com/knu/noticesender/notice/model/Convertible.java
@@ -1,0 +1,5 @@
+package com.knu.noticesender.notice.model;
+
+public interface Convertible {
+    String getDbData();
+}

--- a/src/main/java/com/knu/noticesender/notice/model/Notice.java
+++ b/src/main/java/com/knu/noticesender/notice/model/Notice.java
@@ -1,9 +1,10 @@
 package com.knu.noticesender.notice.model;
 
+import com.knu.noticesender.notice.utils.CategoryConverter;
+import com.knu.noticesender.notice.utils.NoticeTypeConverter;
 import java.time.LocalDateTime;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,19 +22,20 @@ public class Notice {
 
     private String title;
 
-    @Enumerated(EnumType.STRING)
-    private Category category;
 
     private String content;
 
     private LocalDateTime createdDate;
 
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = CategoryConverter.class)
+    private Category category;
+
+    @Convert(converter = NoticeTypeConverter.class)
     private NoticeType type;
 
     @Builder
-    public Notice(Long num, String link, String title, Category category, String content, LocalDateTime createdDate,
-                  NoticeType type) {
+    public Notice(Long num, String link, String title, Category category,
+                  String content, LocalDateTime createdDate, NoticeType type) {
         this.num = num;
         this.link = link;
         this.title = title;

--- a/src/main/java/com/knu/noticesender/notice/model/NoticeType.java
+++ b/src/main/java/com/knu/noticesender/notice/model/NoticeType.java
@@ -5,8 +5,20 @@ package com.knu.noticesender.notice.model;
  * UPDATE: 업데이트된 공지사항
  * OLD: 알림 발송 완료 공지사항
  */
-public enum NoticeType {
-    NEW,
-    UPDATE,
-    OLD
+public enum NoticeType implements Convertible {
+    NEW("", "발송 대기 공지사항"),
+    UPDATE("", "업데이트된 공지사항"),
+    OLD("", "발송 완료 공지사항");
+
+    private final String dbData;
+    private final String desc;
+
+    NoticeType (String dbData, String desc) {
+        this.dbData = dbData;
+        this.desc = desc;
+    }
+
+    @Override
+    public String getDbData() {return dbData;}
+    public String getDesc() {return this.desc;}
 }

--- a/src/main/java/com/knu/noticesender/notice/utils/CategoryConverter.java
+++ b/src/main/java/com/knu/noticesender/notice/utils/CategoryConverter.java
@@ -1,0 +1,18 @@
+package com.knu.noticesender.notice.utils;
+
+import com.knu.noticesender.notice.model.Category;
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class CategoryConverter implements AttributeConverter<Category, String> {
+    @Override
+    public String convertToDatabaseColumn(Category attribute) {
+        return EnumDbConvertUtils.toDbData(attribute);
+    }
+
+    @Override
+    public Category convertToEntityAttribute(String dbData) {
+        return EnumDbConvertUtils.ofDbData(dbData, Category.class);
+    }
+}

--- a/src/main/java/com/knu/noticesender/notice/utils/EnumDbConvertUtils.java
+++ b/src/main/java/com/knu/noticesender/notice/utils/EnumDbConvertUtils.java
@@ -1,0 +1,17 @@
+package com.knu.noticesender.notice.utils;
+
+import com.knu.noticesender.notice.model.Convertible;
+import java.util.Arrays;
+
+public class EnumDbConvertUtils {
+    public static <T extends Enum<T> & Convertible> T ofDbData(String dbData, Class<T> enumClazz) {
+        return Arrays.stream(enumClazz.getEnumConstants())
+                .filter(e -> e.getDbData().equals(dbData))
+                .findAny()
+                .orElseThrow(() -> new RuntimeException(dbData + " 가 존재하지 않음"));
+    }
+
+    public static <T extends Enum<T> & Convertible> String toDbData(T enumV) {
+        return enumV.getDbData();
+    }
+}

--- a/src/main/java/com/knu/noticesender/notice/utils/NoticeTypeConverter.java
+++ b/src/main/java/com/knu/noticesender/notice/utils/NoticeTypeConverter.java
@@ -1,0 +1,18 @@
+package com.knu.noticesender.notice.utils;
+
+import com.knu.noticesender.notice.model.NoticeType;
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class NoticeTypeConverter implements AttributeConverter<NoticeType, String> {
+    @Override
+    public String convertToDatabaseColumn(NoticeType attribute) {
+        return EnumDbConvertUtils.toDbData(attribute);
+    }
+
+    @Override
+    public NoticeType convertToEntityAttribute(String dbData) {
+        return EnumDbConvertUtils.ofDbData(dbData, NoticeType.class);
+    }
+}


### PR DESCRIPTION
## Description

Enum Class Converter 추가

## Changes

1. Enum 데이터와 DB 데이터 간 의존성을 제거하기 위한 Converter Class 를 추가합니다.
2. 새로 추가될 수 있는 Enum 클래스에 대비해 Convertible interface - EnumDbConverterUtils(Generic Base Converter) 를 추가합니다.

## Test Checklist
