### PR TITLE
공지 저장/업데이트 서비스 추가 및 프로세스 서비스 추가, 메세지 기능 서비스 추가 및 엔티티 추가 생성 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 //    Spring Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+// Spring validation
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
+
 //    DevTools
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/src/main/java/com/knu/noticesender/NoticeSenderApplication.java
+++ b/src/main/java/com/knu/noticesender/NoticeSenderApplication.java
@@ -2,8 +2,10 @@ package com.knu.noticesender;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class NoticeSenderApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/knu/noticesender/core/dto/Result.java
+++ b/src/main/java/com/knu/noticesender/core/dto/Result.java
@@ -1,10 +1,12 @@
 package com.knu.noticesender.core.dto;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Result<T> {
     private T data;
 }

--- a/src/main/java/com/knu/noticesender/core/dto/Result.java
+++ b/src/main/java/com/knu/noticesender/core/dto/Result.java
@@ -1,12 +1,14 @@
 package com.knu.noticesender.core.dto;
 
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import javax.validation.Valid;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Result<T> {
+    @Valid
     private T data;
 }

--- a/src/main/java/com/knu/noticesender/core/dto/Result.java
+++ b/src/main/java/com/knu/noticesender/core/dto/Result.java
@@ -1,0 +1,10 @@
+package com.knu.noticesender.core.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class Result<T> {
+    private T data;
+}

--- a/src/main/java/com/knu/noticesender/core/model/BaseEntity.java
+++ b/src/main/java/com/knu/noticesender/core/model/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.knu.noticesender.core.model;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@MappedSuperclass
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime created_at;
+
+    @LastModifiedDate
+    private LocalDateTime updated_at;
+}

--- a/src/main/java/com/knu/noticesender/core/model/BaseEntity.java
+++ b/src/main/java/com/knu/noticesender/core/model/BaseEntity.java
@@ -17,9 +17,10 @@ import java.time.LocalDateTime;
 public class BaseEntity {
 
     @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime created_at;
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updated_at;
+    @Column(name = "created_at")
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/knu/noticesender/notice/NoticeSenderManager.java
+++ b/src/main/java/com/knu/noticesender/notice/NoticeSenderManager.java
@@ -26,7 +26,7 @@ public class NoticeSenderManager implements SenderManager {
     private final NoticeSenderMapper noticeSenderMapper;
 
     /**
-     * 미발송 알림 전송
+     * 미발송 알림을 모두 전송합니다.
      */
     public void sendAll() {
         doSend(noticeRecordService.findAllNotSent());

--- a/src/main/java/com/knu/noticesender/notice/NoticeSenderManager.java
+++ b/src/main/java/com/knu/noticesender/notice/NoticeSenderManager.java
@@ -55,9 +55,9 @@ public class NoticeSenderManager implements SenderManager {
             noticeSender.send(dto);
             postSend(record);
         } catch (HttpClientErrorException e) {
-            log.error(String.format("Sender[%s] Notice[%d] 발송 실패", sender, noticeId));
+            log.error(String.format("Sender[%s] Notice[%d] 발송 실패", sender, noticeId), e);
         } catch (Exception e) {
-            log.error(String.format("Sender[%s] Notice[%d] 저장 실패", sender, noticeId));
+            log.error(String.format("Sender[%s] Notice[%d] 저장 실패", sender, noticeId), e);
         }
     }
 

--- a/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
+++ b/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
@@ -1,0 +1,26 @@
+package com.knu.noticesender.notice.controller;
+
+import com.knu.noticesender.core.dto.Result;
+import com.knu.noticesender.notice.dto.NoticeSaveReqDto;
+import com.knu.noticesender.notice.service.NoticeSaveService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequestMapping("/notice")
+@RequiredArgsConstructor
+public class NoticeController {
+    final NoticeSaveService noticeSaveService;
+
+    @PostMapping
+    void saveNotice(@RequestBody @Valid Result<List<NoticeSaveReqDto>> data) {
+        noticeSaveService.saveOrUpdateNotices(data);
+    }
+
+}

--- a/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
+++ b/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
@@ -3,7 +3,6 @@ package com.knu.noticesender.notice.controller;
 import com.knu.noticesender.core.dto.Result;
 import com.knu.noticesender.notice.dto.NoticeSaveReqDto;
 import com.knu.noticesender.notice.service.NoticeProcessService;
-import com.knu.noticesender.notice.service.NoticeSaveService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
+++ b/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
@@ -18,7 +18,7 @@ import java.util.List;
 @RequestMapping("/notice")
 @RequiredArgsConstructor
 public class NoticeController {
-    final NoticeProcessService noticeProcessService;
+    private final NoticeProcessService noticeProcessService;
 
     @PostMapping
     void saveOrUpdateNotices(@RequestBody @Valid Result<List<NoticeSaveReqDto>> data) {

--- a/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
+++ b/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
@@ -4,6 +4,7 @@ import com.knu.noticesender.core.dto.Result;
 import com.knu.noticesender.notice.dto.NoticeSaveReqDto;
 import com.knu.noticesender.notice.service.NoticeSaveService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.validation.Valid;
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/notice")
 @RequiredArgsConstructor

--- a/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
+++ b/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
@@ -19,7 +19,7 @@ public class NoticeController {
     final NoticeSaveService noticeSaveService;
 
     @PostMapping
-    void saveNotice(@RequestBody @Valid Result<List<NoticeSaveReqDto>> data) {
+    void saveOrUpdateNotices(@RequestBody @Valid Result<List<NoticeSaveReqDto>> data) {
         noticeSaveService.saveOrUpdateNotices(data);
     }
 

--- a/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
+++ b/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
@@ -2,6 +2,7 @@ package com.knu.noticesender.notice.controller;
 
 import com.knu.noticesender.core.dto.Result;
 import com.knu.noticesender.notice.dto.NoticeSaveReqDto;
+import com.knu.noticesender.notice.service.NoticeProcessService;
 import com.knu.noticesender.notice.service.NoticeSaveService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,12 +19,11 @@ import java.util.List;
 @RequestMapping("/notice")
 @RequiredArgsConstructor
 public class NoticeController {
-    final NoticeSaveService noticeSaveService;
+    final NoticeProcessService noticeProcessService;
 
     @PostMapping
     void saveOrUpdateNotices(@RequestBody @Valid Result<List<NoticeSaveReqDto>> data) {
         log.info("[공지 크롤링 요청] {}개의 요청을 처리합니다.", data.getData().size());
-        noticeSaveService.saveOrUpdateNotices(data);
+        noticeProcessService.saveAndSendNotices(data);
     }
-
 }

--- a/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
+++ b/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
@@ -20,6 +20,7 @@ public class NoticeController {
 
     @PostMapping
     void saveOrUpdateNotices(@RequestBody @Valid Result<List<NoticeSaveReqDto>> data) {
+        log.info("[공지 크롤링 요청] {}개의 요청을 처리합니다.", data.getData().size());
         noticeSaveService.saveOrUpdateNotices(data);
     }
 

--- a/src/main/java/com/knu/noticesender/notice/dto/NoticeSaveReqDto.java
+++ b/src/main/java/com/knu/noticesender/notice/dto/NoticeSaveReqDto.java
@@ -1,0 +1,40 @@
+package com.knu.noticesender.notice.dto;
+
+import com.knu.noticesender.notice.model.Category;
+import com.knu.noticesender.notice.model.Notice;
+import com.knu.noticesender.notice.model.NoticeType;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+
+@Getter
+public class NoticeSaveReqDto {
+
+    @NotNull
+    private Long num;
+    @NotNull
+    private Category category;
+    @NotNull
+    private NoticeType type;
+    @NotNull
+    private String link;
+    @NotNull
+    private String title;
+    private String content;
+    @NotNull
+    private LocalDateTime createdDate;
+
+    public static Notice toEntity(NoticeSaveReqDto dto) {
+        return Notice.builder()
+                .num(dto.getNum())
+                .category(dto.getCategory())
+                .type(dto.getType())
+                .link(dto.getLink())
+                .title(dto.getTitle())
+                        .content(dto.getContent())
+                .createdDate(dto.getCreatedDate())
+                .build();
+    }
+}

--- a/src/main/java/com/knu/noticesender/notice/dto/NoticeSaveReqDto.java
+++ b/src/main/java/com/knu/noticesender/notice/dto/NoticeSaveReqDto.java
@@ -1,5 +1,7 @@
 package com.knu.noticesender.notice.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.knu.noticesender.notice.model.Category;
 import com.knu.noticesender.notice.model.Notice;
 import com.knu.noticesender.notice.model.NoticeType;
@@ -8,32 +10,36 @@ import lombok.Getter;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
-
 @Getter
 public class NoticeSaveReqDto {
 
     @NotNull
     private Long num;
+
     @NotNull
     private Category category;
-    @NotNull
-    private NoticeType type;
+
     @NotNull
     private String link;
+
     @NotNull
     private String title;
+
     private String content;
+
     @NotNull
+    @JsonFormat(pattern="yyyy-MM-dd HH:mm:ss")
+    @JsonProperty("created_at")
     private LocalDateTime createdDate;
 
     public static Notice toEntity(NoticeSaveReqDto dto) {
         return Notice.builder()
                 .num(dto.getNum())
                 .category(dto.getCategory())
-                .type(dto.getType())
+                .type(NoticeType.NEW)
                 .link(dto.getLink())
                 .title(dto.getTitle())
-                        .content(dto.getContent())
+                .content(dto.getContent())
                 .createdDate(dto.getCreatedDate())
                 .build();
     }

--- a/src/main/java/com/knu/noticesender/notice/dto/NoticeSaveReqDto.java
+++ b/src/main/java/com/knu/noticesender/notice/dto/NoticeSaveReqDto.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Getter
 public class NoticeSaveReqDto {
@@ -42,5 +43,11 @@ public class NoticeSaveReqDto {
                 .content(dto.getContent())
                 .createdDate(dto.getCreatedDate())
                 .build();
+    }
+
+    public boolean isDifferentWith(Notice notice) {
+        return !Objects.equals(notice.getTitle(), this.title)
+                || !Objects.equals(notice.getCategory(), this.category)
+                || !Objects.equals(notice.getContent(), this.content);
     }
 }

--- a/src/main/java/com/knu/noticesender/notice/model/Notice.java
+++ b/src/main/java/com/knu/noticesender/notice/model/Notice.java
@@ -80,4 +80,10 @@ public class Notice {
     public void changeType(NoticeType type) {
         this.type = type;
     }
+
+    public static Notice createNoticeFromId(Long id) {
+        return Notice.builder()
+                .id(id)
+                .build();
+    }
 }

--- a/src/main/java/com/knu/noticesender/notice/model/Notice.java
+++ b/src/main/java/com/knu/noticesender/notice/model/Notice.java
@@ -12,6 +12,7 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 
 import lombok.*;
+import org.hibernate.annotations.Comment;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.data.annotation.CreatedDate;
 
@@ -35,14 +36,17 @@ public class Notice {
 
     private String content;
 
-    @Column(name = "created_at", columnDefinition = "공지가 실제 생성된 날짜")
+    @Column(name = "created_at")
+    @Comment("공지가 실제 생성된 날짜")
     private LocalDateTime createdDate;
 
-    @Column(name = "saved_at", columnDefinition = "DB에 공지가 저장된 시각")
+    @Column(name = "saved_at")
+    @Comment("DB에 공지가 저장된 시각")
     @CreatedDate
     private LocalDateTime savedAt;
 
-    @Column(name = "updated_at", columnDefinition = "DB에 공지가 업데이트 된 시각")
+    @Column(name = "updated_at")
+    @Comment("DB에 공지가 업데이트 된 시각")
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 

--- a/src/main/java/com/knu/noticesender/notice/model/Notice.java
+++ b/src/main/java/com/knu/noticesender/notice/model/Notice.java
@@ -10,10 +10,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+
+import lombok.*;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.data.annotation.CreatedDate;
 
@@ -66,6 +64,13 @@ public class Notice {
         this.createdDate = createdDate;
         this.category = category;
         this.type = type;
+    }
+
+    public void setUpdatedData(String title, String content, Category category){
+        this.title = title;
+        this.content = content;
+        this.category = category;
+        this.type = NoticeType.UPDATE;
     }
 
     public void changeType(NoticeType type) {

--- a/src/main/java/com/knu/noticesender/notice/model/Notice.java
+++ b/src/main/java/com/knu/noticesender/notice/model/Notice.java
@@ -70,7 +70,7 @@ public class Notice {
         this.type = type;
     }
 
-    public void setUpdatedData(String title, String content, Category category){
+    public void setUpdatedData(String title, String content, Category category) {
         this.title = title;
         this.content = content;
         this.category = category;

--- a/src/main/java/com/knu/noticesender/notice/model/Notice.java
+++ b/src/main/java/com/knu/noticesender/notice/model/Notice.java
@@ -14,6 +14,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.annotation.CreatedDate;
 
 /**
  * 서버 - 데이터베이스 간 공유하는 알림 데이터 클래스
@@ -35,8 +37,16 @@ public class Notice {
 
     private String content;
 
-    @Column(name = "created_at")
+    @Column(name = "created_at", columnDefinition = "공지가 실제 생성된 날짜")
     private LocalDateTime createdDate;
+
+    @Column(name = "saved_at", columnDefinition = "DB에 공지가 저장된 시각")
+    @CreatedDate
+    private LocalDateTime savedAt;
+
+    @Column(name = "updated_at", columnDefinition = "DB에 공지가 업데이트 된 시각")
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
 
     @Convert(converter = CategoryConverter.class)
     private Category category;

--- a/src/main/java/com/knu/noticesender/notice/model/NoticeMessage.java
+++ b/src/main/java/com/knu/noticesender/notice/model/NoticeMessage.java
@@ -42,5 +42,7 @@ public class NoticeMessage extends BaseEntity {
         this.noticeType = notice.getType();
     }
 
+    public void setIsRecorded(boolean isRecorded) {
+        this.isRecorded = isRecorded;
     }
 }

--- a/src/main/java/com/knu/noticesender/notice/model/NoticeMessage.java
+++ b/src/main/java/com/knu/noticesender/notice/model/NoticeMessage.java
@@ -1,0 +1,38 @@
+package com.knu.noticesender.notice.model;
+
+import com.knu.noticesender.core.model.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Table(name = "NOTICE_MESSAGE")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoticeMessage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id")
+    private Notice notice;
+
+    @Column(name = "is_recorded")
+    private boolean isRecorded;
+
+    @Builder
+    public NoticeMessage(Long id, Notice notice, boolean isRecorded) {
+        this.id = id;
+        this.notice = notice;
+        this.isRecorded = isRecorded;
+    }
+
+    public NoticeMessage(Notice notice) {
+        this.notice = notice;
+    }
+}

--- a/src/main/java/com/knu/noticesender/notice/model/NoticeMessage.java
+++ b/src/main/java/com/knu/noticesender/notice/model/NoticeMessage.java
@@ -1,6 +1,7 @@
 package com.knu.noticesender.notice.model;
 
 import com.knu.noticesender.core.model.BaseEntity;
+import com.knu.noticesender.notice.utils.NoticeTypeConverter;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,6 +26,10 @@ public class NoticeMessage extends BaseEntity {
     @Column(name = "is_recorded")
     private boolean isRecorded;
 
+    @Column(name = "notice_status")
+    @Convert(converter = NoticeTypeConverter.class)
+    private NoticeType noticeType;
+
     @Builder
     public NoticeMessage(Long id, Notice notice, boolean isRecorded) {
         this.id = id;
@@ -34,5 +39,8 @@ public class NoticeMessage extends BaseEntity {
 
     public NoticeMessage(Notice notice) {
         this.notice = notice;
+        this.noticeType = notice.getType();
+    }
+
     }
 }

--- a/src/main/java/com/knu/noticesender/notice/model/NoticeRecord.java
+++ b/src/main/java/com/knu/noticesender/notice/model/NoticeRecord.java
@@ -110,9 +110,4 @@ public class NoticeRecord {
         }
         return records;
     }
-
-    public Notice getNotice() {
-        this.notice.changeType(this.noticeType);
-        return this.notice;
-    }
 }

--- a/src/main/java/com/knu/noticesender/notice/model/NoticeType.java
+++ b/src/main/java/com/knu/noticesender/notice/model/NoticeType.java
@@ -8,8 +8,7 @@ package com.knu.noticesender.notice.model;
  */
 public enum NoticeType implements Convertible {
     NEW("NEW", "알림 레코드 생성 대기 공지사항"),
-    UPDATE("UPDATE", "알림 레코드 재생성 대기 공지사항"),
-    OLD("OLD", "알림 레코드 생성 완료 공지사항");
+    UPDATE("UPDATE", "알림 레코드 재생성 대기 공지사항");
 
     private final String dbData;
     private final String desc;

--- a/src/main/java/com/knu/noticesender/notice/repository/NoticeMessageRepository.java
+++ b/src/main/java/com/knu/noticesender/notice/repository/NoticeMessageRepository.java
@@ -1,0 +1,8 @@
+package com.knu.noticesender.notice.repository;
+
+import com.knu.noticesender.notice.model.Notice;
+import com.knu.noticesender.notice.model.NoticeMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeMessageRepository extends JpaRepository<NoticeMessage, Long> {
+}

--- a/src/main/java/com/knu/noticesender/notice/repository/NoticeMessageRepository.java
+++ b/src/main/java/com/knu/noticesender/notice/repository/NoticeMessageRepository.java
@@ -3,6 +3,15 @@ package com.knu.noticesender.notice.repository;
 import com.knu.noticesender.notice.model.Notice;
 import com.knu.noticesender.notice.model.NoticeMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface NoticeMessageRepository extends JpaRepository<NoticeMessage, Long> {
+    @Query("select nm from NoticeMessage nm join fetch nm.notice where nm.isRecorded = :isRecorded")
+    List<NoticeMessage> findAllByIsRecorded(@Param("isRecorded") boolean isRecorded);
+
+    Optional<NoticeMessage> findByNotice(Notice notice);
 }

--- a/src/main/java/com/knu/noticesender/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/knu/noticesender/notice/repository/NoticeRepository.java
@@ -3,8 +3,18 @@ package com.knu.noticesender.notice.repository;
 import com.knu.noticesender.notice.model.Notice;
 import com.knu.noticesender.notice.model.NoticeType;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
     List<Notice> findAllByType(NoticeType type);
+
+    Optional<Notice> findByNum(Long num);
+
+    boolean existsByNum(Long num);
+
+    default boolean notExistsByNum(Long num) {
+        return !existsByNum(num);
+    }
 }

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeMessageService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeMessageService.java
@@ -1,0 +1,35 @@
+package com.knu.noticesender.notice.service;
+
+import com.knu.noticesender.notice.dto.NoticeDto;
+import com.knu.noticesender.notice.dto.NoticeMessageDto;
+import com.knu.noticesender.notice.model.Notice;
+import com.knu.noticesender.notice.model.NoticeMessage;
+import com.knu.noticesender.notice.repository.NoticeMessageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NoticeMessageService {
+
+    private final NoticeMessageRepository noticeMessageRepository;
+
+    public List<NoticeDto> findAllUnrecordedNotices() {
+        List<NoticeMessage> noticeMessages = noticeMessageRepository.findAllByIsRecorded(false);
+
+        return noticeMessages.stream()
+                .map(noticeMessage -> NoticeDto.ofEntity(noticeMessage.getNotice()))
+                .collect(Collectors.toList());
+    }
+
+    public void setIsRecordedOfMessageTrue(NoticeDto noticeDto) {
+        NoticeMessage noticeMessage = noticeMessageRepository.findByNotice(Notice.builder().id(noticeDto.getId()).build())
+                .orElseThrow(() -> new RuntimeException("공지가 존재하지 않습니다"));
+        noticeMessage.setIsRecorded(true);
+    }
+}

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeMessageService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeMessageService.java
@@ -18,6 +18,11 @@ public class NoticeMessageService {
 
     private final NoticeMessageRepository noticeMessageRepository;
 
+    /**
+     * record 테이블에 저장되지 않은 모든 notice를 가져온다
+     *
+     * @return Notice dto 리스트 - notice 데이터이나 읽기 전용임
+     */
     public List<NoticeDto> findAllUnrecordedNotices() {
         List<NoticeMessage> noticeMessages = noticeMessageRepository.findAllByIsRecorded(false);
 
@@ -25,6 +30,12 @@ public class NoticeMessageService {
                 .map(noticeMessage -> NoticeDto.ofEntity(noticeMessage.getNotice()))
                 .collect(Collectors.toList());
     }
+
+    /**
+     * 레코드에 저장 후에 메세지의 isRecorded 필드를 True로 만든다
+     *
+     * @param noticeDto notice 읽기 전용 데이터
+     */
 
     public void setIsRecordedOfMessageTrue(NoticeDto noticeDto) {
         NoticeMessage noticeMessage = noticeMessageRepository.findByNotice(Notice.builder().id(noticeDto.getId()).build())

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeMessageService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeMessageService.java
@@ -38,7 +38,7 @@ public class NoticeMessageService {
      */
 
     public void setIsRecordedOfMessageTrue(NoticeDto noticeDto) {
-        NoticeMessage noticeMessage = noticeMessageRepository.findByNotice(Notice.builder().id(noticeDto.getId()).build())
+        NoticeMessage noticeMessage = noticeMessageRepository.findByNotice(Notice.createNoticeFromId(noticeDto.getId()))
                 .orElseThrow(() -> new RuntimeException("공지가 존재하지 않습니다"));
         noticeMessage.setIsRecorded(true);
     }

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeMessageService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeMessageService.java
@@ -1,7 +1,6 @@
 package com.knu.noticesender.notice.service;
 
 import com.knu.noticesender.notice.dto.NoticeDto;
-import com.knu.noticesender.notice.dto.NoticeMessageDto;
 import com.knu.noticesender.notice.model.Notice;
 import com.knu.noticesender.notice.model.NoticeMessage;
 import com.knu.noticesender.notice.repository.NoticeMessageRepository;

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeProcessService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeProcessService.java
@@ -2,7 +2,9 @@ package com.knu.noticesender.notice.service;
 
 import com.knu.noticesender.core.dto.Result;
 import com.knu.noticesender.notice.NoticeSenderManager;
+import com.knu.noticesender.notice.dto.NoticeDto;
 import com.knu.noticesender.notice.dto.NoticeSaveReqDto;
+import com.knu.noticesender.notice.model.NoticeType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,6 +20,11 @@ public class NoticeProcessService {
     private final NoticeSaveService noticeSaveService;
     private final NoticeSenderManager noticeSenderManager;
 
+    /**
+     * 크롤링 데이터 저장 요청을 받아 공지를 저장 후 각 플랫폼 별로 발송합니다
+     *
+     * @param data: 저장할 공지 데이터 리스트 데이터
+     */
     @Transactional
     public void saveAndSendNotices(Result<List<NoticeSaveReqDto>> data) {
         noticeSaveService.saveOrUpdateNotices(data);

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeProcessService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeProcessService.java
@@ -1,0 +1,27 @@
+package com.knu.noticesender.notice.service;
+
+import com.knu.noticesender.core.dto.Result;
+import com.knu.noticesender.notice.NoticeSenderManager;
+import com.knu.noticesender.notice.dto.NoticeSaveReqDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NoticeProcessService {
+    private final NoticeRecordService noticeRecordService;
+    private final NoticeSaveService noticeSaveService;
+    private final NoticeSenderManager noticeSenderManager;
+
+    @Transactional
+    public void saveAndSendNotices(Result<List<NoticeSaveReqDto>> data) {
+        noticeSaveService.saveOrUpdateNotices(data);
+        noticeRecordService.generateRecord();
+        noticeSenderManager.sendAll();
+    }
+}

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeRecordService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeRecordService.java
@@ -3,10 +3,12 @@ package com.knu.noticesender.notice.service;
 import java.util.List;
 import com.knu.noticesender.notice.NoticeSenderManager;
 import com.knu.noticesender.notice.dto.NoticeDto;
+import com.knu.noticesender.notice.model.Notice;
 import com.knu.noticesender.notice.model.NoticeRecord;
 import com.knu.noticesender.notice.model.NoticeRecord.NoticeRecordId;
 import com.knu.noticesender.notice.model.NoticeType;
 import com.knu.noticesender.notice.model.Sender;
+import com.knu.noticesender.notice.repository.NoticeMessageRepository;
 import com.knu.noticesender.notice.repository.NoticeRecordRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,16 +18,16 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class NoticeRecordService {
     private final NoticeRecordRepository noticeRecordRepository;
-    private final NoticeService noticeService;
+    private final NoticeMessageService noticeMessageService;
 
     /**
      * 새로 생성되거나, 업데이트된 알림 데이터를 레코드로 추가
      * @see NoticeRecord
+     * @see NoticeRecord
      */
     @Transactional
     public void generateRecord() {
-        doGenerate(noticeService.findAllByType(NoticeType.NEW));
-        doGenerate(noticeService.findAllByType(NoticeType.UPDATE));
+        doGenerate(noticeMessageService.findAllUnrecordedNotices());
     }
 
     private void doGenerate(List<NoticeDto> newNotices) {
@@ -38,15 +40,8 @@ public class NoticeRecordService {
      */
     private void doGenerate(NoticeDto dto) {
         noticeRecordRepository.saveAll(NoticeRecord.createByNoticeDtoPerSender(dto));
-        postGenerate(dto);
-    }
 
-    /**
-     * 알림 레코드 생성 후 알림 데이터의 상태를 OLD 로 변경한다
-     * @see NoticeType#OLD
-     */
-    private void postGenerate(NoticeDto dto) {
-        noticeService.changeType(dto.getId(), NoticeType.OLD);
+        noticeMessageService.setIsRecordedOfMessageTrue(dto);
     }
 
     /**

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeRecordService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeRecordService.java
@@ -21,9 +21,7 @@ public class NoticeRecordService {
     private final NoticeMessageService noticeMessageService;
 
     /**
-     * 새로 생성되거나, 업데이트된 알림 데이터를 레코드로 추가
-     * @see NoticeRecord
-     * @see NoticeRecord
+     * 저장된 공지에 대한 메세지를 조회하여 플랫폼 별 레코드를 생성합니다
      */
     @Transactional
     public void generateRecord() {

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeSaveService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeSaveService.java
@@ -23,12 +23,14 @@ public class NoticeSaveService {
 
     private final NoticeRepository noticeRepository;
     private final NoticeMessageRepository noticeMessageRepository;
+
     /**
      * 공지사항 크롤링 데이터 저장 요청을 받아,
      * 저장 또는 변경사항이 있을 시 업데이트가 수행됩니다
      *
+     * 현재는 저장 후 message 를 NOTICE_MESSAGE 테이블에 적재하고 있습니다
+     *
      * @param data: 공지사항 크롤링 데이터 리스트를 감싼 객체
-     * @see NoticeSaveReqDto
      */
     @Transactional
     public void saveOrUpdateNotices(Result<List<NoticeSaveReqDto>> data) {

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeSaveService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeSaveService.java
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -68,10 +67,7 @@ public class NoticeSaveService {
 
     private boolean isUpdatedNotice(NoticeSaveReqDto dto) {
         Notice notice = noticeRepository.findByNum(dto.getNum()).orElseThrow(RuntimeException::new);
-
-        return !Objects.equals(notice.getTitle(), dto.getTitle())
-                || !Objects.equals(notice.getCategory(), dto.getCategory())
-                || !Objects.equals(notice.getContent(), dto.getContent());
+        return dto.isDifferentWith(notice);
     }
 
     private Notice updateAndGetNotice(NoticeSaveReqDto dto) {

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeSaveService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeSaveService.java
@@ -51,7 +51,7 @@ public class NoticeSaveService {
                 .filter(dto -> noticeRepository.notExistsByNum(dto.getNum()))
                 .map(NoticeSaveReqDto::toEntity)
                 .collect(Collectors.toList());
-        log.info("[공지 크롤링 요청] {} 개의 공지를 저장했습니다.", notices.size());
+        log.info("[공지 크롤링 요청] {} 개의 공지를 저장합니다.", notices.size());
         noticeRepository.saveAll(notices);
     }
 

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeSaveService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeSaveService.java
@@ -1,0 +1,70 @@
+package com.knu.noticesender.notice.service;
+
+import com.knu.noticesender.core.dto.Result;
+import com.knu.noticesender.notice.dto.NoticeDto;
+import com.knu.noticesender.notice.dto.NoticeSaveReqDto;
+import com.knu.noticesender.notice.model.Notice;
+import com.knu.noticesender.notice.model.NoticeType;
+import com.knu.noticesender.notice.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NoticeSaveService {
+
+    private final NoticeRepository noticeRepository;
+    private final NoticeRecordService noticeRecordService;
+
+    /**
+     * 공지사항 크롤링 데이터 저장 요청을 받아,
+     * 저장 또는 변경사항이 있을 시 업데이트가 수행됩니다
+     *
+     * @param data: 공지사항 크롤링 데이터 리스트를 감싼 객체
+     * @see NoticeSaveReqDto
+     */
+    @Transactional
+    public void saveOrUpdateNotices(Result<List<NoticeSaveReqDto>> data) {
+        saveNoticesIfNotExists(data);
+        updateNoticesWithCondition(data);
+        noticeRecordService.generateRecord();
+
+    }
+
+    private void updateNoticesWithCondition(Result<List<NoticeSaveReqDto>> data) {
+        data.getData().stream()
+                .filter(dto -> noticeRepository.existsByNum(dto.getNum()))
+                .filter(this::isUpdatedNotice)
+                .peek(dto -> log.info("[공지 크롤링 요청] 공지 업데이트 num: {}, category: {}", dto.getNum(), dto.getCategory()))
+                .forEach(this::updateNotice);
+    }
+
+    private void saveNoticesIfNotExists(Result<List<NoticeSaveReqDto>> data) {
+        List<Notice> notices = data.getData().stream()
+                .filter(dto -> noticeRepository.notExistsByNum(dto.getNum()))
+                .map(NoticeSaveReqDto::toEntity)
+                .collect(Collectors.toList());
+        log.info("[공지 크롤링 요청] {} 개의 공지를 저장했습니다.", notices.size());
+        noticeRepository.saveAll(notices);
+    }
+
+    private boolean isUpdatedNotice(NoticeSaveReqDto dto) {
+        Notice notice = noticeRepository.findByNum(dto.getNum()).orElseThrow(RuntimeException::new);
+
+        return !Objects.equals(notice.getTitle(), dto.getTitle())
+                || !Objects.equals(notice.getCategory(), dto.getCategory())
+                || !Objects.equals(notice.getContent(), dto.getContent());
+    }
+
+    private void updateNotice(NoticeSaveReqDto dto) {
+        Notice notice = noticeRepository.findByNum(dto.getNum()).orElseThrow(RuntimeException::new);
+        notice.setUpdatedData(dto.getTitle(), dto.getContent(), dto.getCategory());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,6 @@ discord:
     graduate: ${DISCORD_GRADUATE}
     graduate-contract: ${DISCORD_GRADUATE_CONTRACT}
 
-
 server:
   port: ${PORT}
 
@@ -22,10 +21,10 @@ springdoc:
 
 spring:
   datasource:
-      driver-class-name: com.mysql.cj.jdbc.Driver
-      url: ${DB_URL}
-      username: ${DB_USERNAME}
-      password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
   jpa:
     hibernate:
       ddl-auto:


### PR DESCRIPTION
## Description
크롤링 스크립트에서 API 콜을 통해 서버에서 공지 저장 관리를 처리하도록 합니다

현재 공지 저장/업데이트 서비스, 공지 발송 서비스를 동기적으로 묶어놓았습니다.
크롤링 api 요청시 저장,업데이트 후 공지 발송까지 동기적으로 진행합니다

## Changes
- noticeSaveService 추가
  - saveOrUpdateNotices : 
  공지사항 크롤링 저장 요청을 받아, 저장 또는 업데이트 처리를 진행합니다. 처리 후 해당 공지에 대한 메세지를 특정 테이블에 저장합니다

- noticeMessageServcie 추가
  - 엔티티 NOTICE_MESSAGE가 추가되었습니다
    - 기존의 status(NoticeType)를 공지의 상태를 나타내는 필드를 사용하고, 레코드 테이블에 생성해야한다는 메세지를 NOTICE_MESSAGE 엔티티에서 처리하도록 합니다 
  - 공지 저장, 업데이트 시 메세지를 남기도록 하며 noticeRecordService에서 해당 메세지를 불러와 레코드 테이블에 플랫폼 별로 저장합니다
  
- noticeProcessService 추가
  - 크롤링 요청부터 플랫폼 발송까지 한 프로세스로 동기적으로 묶어놓은 프로세스 서비스이며 해당 부분은 추후 서버 분리 시 제거할 수 있습니다

- 공지 저장 POST api 추가
  - vaildation 라이브러리 추가 및 dto에 vaildation 처리 완료
 
- 일부 유틸성 클래스 추가
  - Result : json객체를 {data: 데이터} 형태로 가져올 때 사용할 수 있는 제네릭 형태의 클래스입니다
  - BaseEntity: 자동 created_at과 updated_at 기능이 포함되어 있습니다
  
## Test Checklist
- dev api 저장 테스트 진행 완료
- 단위 테스트는 추가 pr 진행예정입니다