### PR TITLE
fix: NoticeMessage의 findByNotice 중복 데이터 에러 해결, 로직 변경

### DIFF
--- a/src/main/java/com/knu/noticesender/core/model/BaseEntity.java
+++ b/src/main/java/com/knu/noticesender/core/model/BaseEntity.java
@@ -21,6 +21,6 @@ public class BaseEntity {
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(name = "created_at")
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/knu/noticesender/notice/dto/NoticeMessageDto.java
+++ b/src/main/java/com/knu/noticesender/notice/dto/NoticeMessageDto.java
@@ -22,12 +22,14 @@ public class NoticeMessageDto {
     }
 
     public static NoticeMessageDto fromEntity(NoticeMessage noticeMessage) {
-
-        return NoticeMessageDto.builder()
+        NoticeMessageDto noticeMessageDto = NoticeMessageDto.builder()
                 .id(noticeMessage.getId())
                 .noticeDto(NoticeDto.ofEntity(noticeMessage.getNotice()))
                 .isRecorded(noticeMessage.isRecorded())
                 .noticeType(noticeMessage.getNoticeType())
                 .build();
+        
+        noticeMessageDto.getNoticeDto().setType(noticeMessage.getNoticeType());
+        return noticeMessageDto;
     }
 }

--- a/src/main/java/com/knu/noticesender/notice/dto/NoticeMessageDto.java
+++ b/src/main/java/com/knu/noticesender/notice/dto/NoticeMessageDto.java
@@ -1,0 +1,34 @@
+package com.knu.noticesender.notice.dto;
+
+import com.knu.noticesender.notice.model.Notice;
+import com.knu.noticesender.notice.model.NoticeMessage;
+import com.knu.noticesender.notice.model.NoticeType;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class NoticeMessageDto {
+
+    private Long id;
+    private Notice notice;
+    private boolean isRecorded;
+    private NoticeType noticeType;
+
+    @Builder
+    public NoticeMessageDto(Long id, Notice notice, boolean isRecorded, NoticeType noticeType) {
+        this.id = id;
+        this.notice = notice;
+        this.isRecorded = isRecorded;
+        this.noticeType = noticeType;
+    }
+
+    public static NoticeMessageDto fromEntity(NoticeMessage noticeMessage) {
+
+        return NoticeMessageDto.builder()
+                .id(noticeMessage.getId())
+                .notice(noticeMessage.getNotice())
+                .isRecorded(noticeMessage.isRecorded())
+                .noticeType(noticeMessage.getNoticeType())
+                .build();
+    }
+}

--- a/src/main/java/com/knu/noticesender/notice/dto/NoticeMessageDto.java
+++ b/src/main/java/com/knu/noticesender/notice/dto/NoticeMessageDto.java
@@ -1,6 +1,5 @@
 package com.knu.noticesender.notice.dto;
 
-import com.knu.noticesender.notice.model.Notice;
 import com.knu.noticesender.notice.model.NoticeMessage;
 import com.knu.noticesender.notice.model.NoticeType;
 import lombok.Builder;
@@ -10,14 +9,14 @@ import lombok.Data;
 public class NoticeMessageDto {
 
     private Long id;
-    private NoticeDto notice;
+    private NoticeDto noticeDto;
     private boolean isRecorded;
     private NoticeType noticeType;
 
     @Builder
-    public NoticeMessageDto(Long id, NoticeDto notice, boolean isRecorded, NoticeType noticeType) {
+    public NoticeMessageDto(Long id, NoticeDto noticeDto, boolean isRecorded, NoticeType noticeType) {
         this.id = id;
-        this.notice = notice;
+        this.noticeDto = noticeDto;
         this.isRecorded = isRecorded;
         this.noticeType = noticeType;
     }
@@ -26,7 +25,7 @@ public class NoticeMessageDto {
 
         return NoticeMessageDto.builder()
                 .id(noticeMessage.getId())
-                .notice(NoticeDto.ofEntity(noticeMessage.getNotice()))
+                .noticeDto(NoticeDto.ofEntity(noticeMessage.getNotice()))
                 .isRecorded(noticeMessage.isRecorded())
                 .noticeType(noticeMessage.getNoticeType())
                 .build();

--- a/src/main/java/com/knu/noticesender/notice/dto/NoticeMessageDto.java
+++ b/src/main/java/com/knu/noticesender/notice/dto/NoticeMessageDto.java
@@ -10,12 +10,12 @@ import lombok.Data;
 public class NoticeMessageDto {
 
     private Long id;
-    private Notice notice;
+    private NoticeDto notice;
     private boolean isRecorded;
     private NoticeType noticeType;
 
     @Builder
-    public NoticeMessageDto(Long id, Notice notice, boolean isRecorded, NoticeType noticeType) {
+    public NoticeMessageDto(Long id, NoticeDto notice, boolean isRecorded, NoticeType noticeType) {
         this.id = id;
         this.notice = notice;
         this.isRecorded = isRecorded;
@@ -26,7 +26,7 @@ public class NoticeMessageDto {
 
         return NoticeMessageDto.builder()
                 .id(noticeMessage.getId())
-                .notice(noticeMessage.getNotice())
+                .notice(NoticeDto.ofEntity(noticeMessage.getNotice()))
                 .isRecorded(noticeMessage.isRecorded())
                 .noticeType(noticeMessage.getNoticeType())
                 .build();

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeMessageService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeMessageService.java
@@ -1,6 +1,7 @@
 package com.knu.noticesender.notice.service;
 
 import com.knu.noticesender.notice.dto.NoticeDto;
+import com.knu.noticesender.notice.dto.NoticeMessageDto;
 import com.knu.noticesender.notice.model.Notice;
 import com.knu.noticesender.notice.model.NoticeMessage;
 import com.knu.noticesender.notice.repository.NoticeMessageRepository;
@@ -23,23 +24,26 @@ public class NoticeMessageService {
      *
      * @return Notice dto 리스트 - notice 데이터이나 읽기 전용임
      */
-    public List<NoticeDto> findAllUnrecordedNotices() {
+    public List<NoticeMessageDto> findAllUnrecordedNoticeMessages() {
         List<NoticeMessage> noticeMessages = noticeMessageRepository.findAllByIsRecorded(false);
 
         return noticeMessages.stream()
-                .map(noticeMessage -> NoticeDto.ofEntity(noticeMessage.getNotice()))
+                .map(NoticeMessageDto::fromEntity)
                 .collect(Collectors.toList());
     }
 
     /**
      * 레코드에 저장 후에 메세지의 isRecorded 필드를 True로 만든다
      *
-     * @param noticeDto notice 읽기 전용 데이터
+     * @param noticeMessageDto noticeMessage 읽기 전용 데이터
      */
+    public void setIsRecordedTrue(NoticeMessageDto noticeMessageDto) {
+        if (noticeMessageDto.getId() == null) {
+            throw new RuntimeException("공지 Message dto Id가 null 입니다");
+        }
 
-    public void setIsRecordedOfMessageTrue(NoticeDto noticeDto) {
-        NoticeMessage noticeMessage = noticeMessageRepository.findByNotice(Notice.createNoticeFromId(noticeDto.getId()))
-                .orElseThrow(() -> new RuntimeException("공지가 존재하지 않습니다"));
+        NoticeMessage noticeMessage = noticeMessageRepository.findById(noticeMessageDto.getId())
+                .orElseThrow(() -> new RuntimeException("공지 Message가 존재하지 않습니다"));
         noticeMessage.setIsRecorded(true);
     }
 }

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeRecordService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeRecordService.java
@@ -3,12 +3,11 @@ package com.knu.noticesender.notice.service;
 import java.util.List;
 import com.knu.noticesender.notice.NoticeSenderManager;
 import com.knu.noticesender.notice.dto.NoticeDto;
-import com.knu.noticesender.notice.model.Notice;
+import com.knu.noticesender.notice.dto.NoticeMessageDto;
+import com.knu.noticesender.notice.model.NoticeMessage;
 import com.knu.noticesender.notice.model.NoticeRecord;
 import com.knu.noticesender.notice.model.NoticeRecord.NoticeRecordId;
-import com.knu.noticesender.notice.model.NoticeType;
 import com.knu.noticesender.notice.model.Sender;
-import com.knu.noticesender.notice.repository.NoticeMessageRepository;
 import com.knu.noticesender.notice.repository.NoticeRecordRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,11 +24,11 @@ public class NoticeRecordService {
      */
     @Transactional
     public void generateRecord() {
-        doGenerate(noticeMessageService.findAllUnrecordedNotices());
-    }
-
-    private void doGenerate(List<NoticeDto> newNotices) {
-        newNotices.forEach(this::doGenerate);
+        List<NoticeMessageDto> noticeMessageDtos = noticeMessageService.findAllUnrecordedNoticeMessages();
+        noticeMessageDtos.forEach(noticeMessageDto -> {
+            doGenerate(noticeMessageDto.getNoticeDto());
+            noticeMessageService.setIsRecordedTrue(noticeMessageDto);
+        });
     }
 
     /**
@@ -38,8 +37,6 @@ public class NoticeRecordService {
      */
     private void doGenerate(NoticeDto dto) {
         noticeRecordRepository.saveAll(NoticeRecord.createByNoticeDtoPerSender(dto));
-
-        noticeMessageService.setIsRecordedOfMessageTrue(dto);
     }
 
     /**


### PR DESCRIPTION
## Description
기존 oticeMessage의 isRecord 필드를 true로 변경하는 로직은, 레코드 데이터 생성 후 notice 데이터를 기준으로 메세지를 찾은 후 필드값을 변경하는 행위였습니다.
만약 Notice가 업데이트 될 시 noticeMessage는 동일한 Notice를 가진 2개 이상의 데이터가 생성됩니다 기존 로직의 findByNotice 시 unique 에러가 발생합니다. 이를 수정하기위해 해당 커밋을 통해 변경합니다

## Changes

- NoticeRecordService에 NoticeMessage를 넘겨줍니다. Record 생성 처리 후 NoticeMessage의 id값을 이용해 필드값(isRecorded)를 변경합니다
- BaseEntity 필드명 실수 수정 (created_at -> updated_at)
- NoitceMessageDto 를 생성합니다.
  - 외부 서비스로 NoticeMessage 반출할 시 실제 데이터 변경을 막기 위함입니다
   - NoticeMessageDto 안의 NoticeDto의 type값을 NoticeMessage의 NoticeType으로 세팅합니다
     - NoticeMessage 저장 당시의 값으로 레코드 데이터를 세팅하기 위함입니다  
## Test Checklist

로컬 테스트 결과 이상없었으며 merge 진행하겠습니다
- new 게시글 2건 테스트
- update 게시글 2건 테스트
