### PR TITLE
feat: 공지 저장 전용 기능 추가(알림 x) 

### DIFF
--- a/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
+++ b/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
@@ -3,6 +3,7 @@ package com.knu.noticesender.notice.controller;
 import com.knu.noticesender.core.dto.Result;
 import com.knu.noticesender.notice.dto.NoticeSaveReqDto;
 import com.knu.noticesender.notice.service.NoticeProcessService;
+import com.knu.noticesender.notice.service.NoticeSaveService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NoticeController {
     private final NoticeProcessService noticeProcessService;
+    private final NoticeSaveService noticeSaveService;
 
     @PostMapping("/process")
     void saveAndSendNotices(@RequestBody @Valid Result<List<NoticeSaveReqDto>> data) {
@@ -29,6 +31,6 @@ public class NoticeController {
     @PostMapping
     void saveOrUpdateNotices(@RequestBody @Valid Result<List<NoticeSaveReqDto>> data) {
         log.info("[공지 크롤링 요청] {}개의 요청을 저장합니다.", data.getData().size());
-        noticeProcessService.saveNotices(data);
+        noticeSaveService.saveOrUpdateNotices(data);
     }
 }

--- a/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
+++ b/src/main/java/com/knu/noticesender/notice/controller/NoticeController.java
@@ -20,9 +20,15 @@ import java.util.List;
 public class NoticeController {
     private final NoticeProcessService noticeProcessService;
 
-    @PostMapping
-    void saveOrUpdateNotices(@RequestBody @Valid Result<List<NoticeSaveReqDto>> data) {
+    @PostMapping("/process")
+    void saveAndSendNotices(@RequestBody @Valid Result<List<NoticeSaveReqDto>> data) {
         log.info("[공지 크롤링 요청] {}개의 요청을 처리합니다.", data.getData().size());
         noticeProcessService.saveAndSendNotices(data);
+    }
+
+    @PostMapping
+    void saveOrUpdateNotices(@RequestBody @Valid Result<List<NoticeSaveReqDto>> data) {
+        log.info("[공지 크롤링 요청] {}개의 요청을 저장합니다.", data.getData().size());
+        noticeProcessService.saveNotices(data);
     }
 }

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeProcessService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeProcessService.java
@@ -6,7 +6,6 @@ import com.knu.noticesender.notice.dto.NoticeSaveReqDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeProcessService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeProcessService.java
@@ -2,9 +2,7 @@ package com.knu.noticesender.notice.service;
 
 import com.knu.noticesender.core.dto.Result;
 import com.knu.noticesender.notice.NoticeSenderManager;
-import com.knu.noticesender.notice.dto.NoticeDto;
 import com.knu.noticesender.notice.dto.NoticeSaveReqDto;
-import com.knu.noticesender.notice.model.NoticeType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,9 +23,8 @@ public class NoticeProcessService {
      *
      * @param data: 저장할 공지 데이터 리스트 데이터
      */
-    @Transactional
     public void saveAndSendNotices(Result<List<NoticeSaveReqDto>> data) {
-        noticeSaveService.saveOrUpdateNotices(data);
+        noticeSaveService.saveOrUpdateNoticesWithMessage(data);
         noticeRecordService.generateRecord();
         noticeSenderManager.sendAll();
     }

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeSaveService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeSaveService.java
@@ -32,11 +32,24 @@ public class NoticeSaveService {
      * @param data: 공지사항 크롤링 데이터 리스트를 감싼 객체
      */
     @Transactional
+    public void saveOrUpdateNoticesWithMessage(Result<List<NoticeSaveReqDto>> data) {
+        List<Notice> notices = saveNoticesIfNotExists(data);
+        notices.addAll(updateNoticesWithCondition(data));
+        saveNoticeMessages(notices);
+    }
+
+    /**
+     * 공지사항 크롤링 데이터 저장 요청을 받아,
+     * 저장 또는 변경사항이 있을 시 업데이트가 수행됩니다
+     *
+     * 저장 전용이며 알림 발송을 위한 메세지를 저장하지 않습니다.
+     *
+     * @param data: 공지사항 크롤링 데이터 리스트를 감싼 객체
+     */
+    @Transactional
     public void saveOrUpdateNotices(Result<List<NoticeSaveReqDto>> data) {
         List<Notice> notices = saveNoticesIfNotExists(data);
         notices.addAll(updateNoticesWithCondition(data));
-
-        saveNoticeMessages(notices);
     }
 
     private List<Notice> updateNoticesWithCondition(Result<List<NoticeSaveReqDto>> data) {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -34,3 +34,8 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+logging:
+  level:
+    root: debug
+  config:
+    path: ./logs


### PR DESCRIPTION
## Description
- 전체 공지 데이터를 저장할 때 알림까지 연동이되면 100개 이상의 알림이 울리고 limit에 걸릴 수 있기 때문에 추가합니다

## Changes
- 저장 전용 로직을 추가하고 컨트롤러를 추가합니다
  - 알림 포함은 `notice/process` , 저장 전용은 `/notce` 로 POST요청을 보내도록 합니다 

## Test Checklist
- 로컬 테스트 성공
