### PR TITLE
feat: 서버 time-zone(Asia/Seoul) 설정 추가

### DIFF
--- a/src/main/java/com/knu/noticesender/config/timeZoneConfig.java
+++ b/src/main/java/com/knu/noticesender/config/timeZoneConfig.java
@@ -1,0 +1,18 @@
+package com.knu.noticesender.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
+
+@Configuration
+@Slf4j
+public class timeZoneConfig {
+
+    @PostConstruct
+    void setTimeZoneSeoul() {
+        log.info("time zone(Asia/Seoul) setting complete");
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+}


### PR DESCRIPTION
## Description
- 서버 time zone이 UTC 기준으로 되어있어 created_at, updated_at 등이 UTC 기준으로 저장이 되고있습니다.
- EC2를 Asia/Seoul 로 세팅하는 것 보다 서버 코드 자체로 컨트롤하도록 합니다

## Changes
- 서버 타임존을 asia/seoul로 세팅하여 해당 문제를 해결합니다.

## Test Checklist
