### PR TITLE
fix: 로그 time-zone 세팅 

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,7 +3,6 @@
 <configuration scan="true" scanPeriod="60 seconds">
     <!-- logging level -->
     <springProperty scope="context" name="LOG_LEVEL" source="logging.level.root"/>
-
     <!-- log file path -->
     <springProperty name="LOG_PATH" source="logging.config.path"/>
     <!-- log file name -->
@@ -12,8 +11,8 @@
     <property name="ERR_LOG_FILE_NAME" value="err_log"/>
 
     <!-- pattern -->
-    <property name="CONSOLE_LOG_PATTERN" value="%highlight(%-5level) %magenta([%d{yy-MM-dd HH:mm:ss}]) %msg - %green([%logger{0}:%line]) %n"/>
-    <property name="LOG_PATTERN" value="%-5level [%d{yy-MM-dd HH:mm:ss}][%thread] [%X{traceId}] [%logger{0}:%line] - %msg%n"/>
+    <property name="CONSOLE_LOG_PATTERN" value="%highlight(%-5level) %magenta([%d{yy-MM-dd HH:mm:ss,Asia/Seoul}]) %msg - %green([%logger{0}:%line]) %n"/>
+    <property name="LOG_PATTERN" value="%-5level [%d{yy-MM-dd HH:mm:ss,Asia/Seoul}][%thread] [%X{traceId}] [%logger{0}:%line] - %msg%n"/>
 
     <!--Console Appender-->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
## Description
- 로그백이 시스템 시간 영향을 받음, 이 때문에 로그가 UTC기준으로 찍히고 있음

## Changes
- logback의 DateFormat 패턴을 수정함(Asia/seoul)

## Test Checklist
