### PR TITLE
Add: payload 로깅에서 제외할 uri 목록 추가 및 로깅 제외

### DIFF
--- a/src/main/java/com/knu/noticesender/logger/LoggingFilter.java
+++ b/src/main/java/com/knu/noticesender/logger/LoggingFilter.java
@@ -82,7 +82,7 @@ public class LoggingFilter extends OncePerRequestFilter {
                 queryString == null ? requestURI: requestURI + queryString,
                 request.getContentType()
         );
-        if (LoggingSupport.toLogPayload(requestURI)) {
+        if (LoggingSupport.isUrlToLogPayload(requestURI)) {
             logPayload("Request", request.getContentType(), request.getInputStream());
         }
     }
@@ -132,11 +132,8 @@ public class LoggingFilter extends OncePerRequestFilter {
             noPayloadUris.add("/notice");
         }
 
-        public static boolean toLogPayload(String requestURI) {
-            for (String uri : noPayloadUris) {
-                if (requestURI.startsWith(uri)) { return false; }
-            }
-            return true;
+        public static boolean isUrlToLogPayload(String requestURI) {
+            return noPayloadUris.stream().noneMatch(requestURI::startsWith);
         }
     }
 }

--- a/src/main/java/com/knu/noticesender/notice/service/NoticeSaveService.java
+++ b/src/main/java/com/knu/noticesender/notice/service/NoticeSaveService.java
@@ -59,17 +59,17 @@ public class NoticeSaveService {
                 .peek(dto -> log.info("[공지 크롤링 요청] 공지 업데이트 num: {}, category: {}", dto.getNum(), dto.getCategory()))
                 .map(this::updateAndGetNotice)
                 .collect(Collectors.toList());
-
     }
 
     private List<Notice> saveNoticesIfNotExists(Result<List<NoticeSaveReqDto>> data) {
-        List<Notice> notices = data.getData().stream()
+        List<Notice> savedNotices = data.getData().stream()
                 .filter(dto -> noticeRepository.notExistsByNum(dto.getNum()))
                 .map(NoticeSaveReqDto::toEntity)
+                .peek(savedNotice -> {log.info("[공지 크롤링 요청] 공지 저장 num: {}, title: {}, link: {}", savedNotice.getNum(), savedNotice.getTitle(), savedNotice.getLink());})
                 .collect(Collectors.toList());
-        log.info("[공지 크롤링 요청] {} 개의 공지를 저장합니다.", notices.size());
 
-        return noticeRepository.saveAll(notices);
+        log.info("[공지 크롤링 요청] {} 개의 공지를 저장합니다.", savedNotices.size());
+        return noticeRepository.saveAll(savedNotices);
     }
 
     private void saveNoticeMessages(List<Notice> notices) {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,13 +1,13 @@
 discord:
   urls:
-    all: ${DISCORD_ALL}
-    student: ${DISCORD_STUDENT}
-    normal: ${DISCORD_NORMAL}
-    scholarship: ${DISCORD_SCHOLARSHIP}
-    sim-com: ${DISCORD_SIM_COM}
-    gl-sop: ${DISCORD_GL_SOP}
-    graduate: ${DISCORD_GRADUATE}
-    graduate-contract: ${DISCORD_GRADUATE_CONTRACT}
+    all: ${DISCORD_DEV}
+    student: ${DISCORD_DEV}
+    normal: ${DISCORD_DEV}
+    scholarship: ${DISCORD_DEV}
+    sim-com: ${DISCORD_DEV}
+    gl-sop: ${DISCORD_DEV}
+    graduate: ${DISCORD_DEV}
+    graduate-contract: ${DISCORD_DEV}
 
 server:
   port: ${PORT}
@@ -22,9 +22,9 @@ springdoc:
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: ${DB_DEV_URL}
+    username: ${DB_DEV_USERNAME}
+    password: ${DB_DEV_PASSWORD}
   jpa:
     hibernate:
       ddl-auto:
@@ -38,4 +38,4 @@ logging:
   level:
     root: debug
   config:
-    path: ./logs
+    path: ${LOGGING_PATH}


### PR DESCRIPTION
## Description

기존 payload 에 공지사항 content 데이터를 로깅하고 있었습니다.

content 데이터의 길이가 길 경우 다른 로깅 데이터를 확인하기 힘든 문제가 있었고, 현재 별도의 로그 분석 과정을 필요로하지 않기 때문에 로깅 데이터에서 제외합니다.

## Changes

payload 로깅 여부를 반환하는 함수를 추가합니다 (LoggingSupport.toLogPayload)

## Test Checklist
