### PR TITLE
Feat: Response 규칙, Exception 규칙 클래스 추가

### DIFF
--- a/src/main/java/com/knu/noticesender/core/controller/HelloController.java
+++ b/src/main/java/com/knu/noticesender/core/controller/HelloController.java
@@ -1,0 +1,18 @@
+package com.knu.noticesender.core.controller;
+
+import com.knu.noticesender.core.exception.KnuException;
+import com.knu.noticesender.core.response.ApiResponse;
+import com.knu.noticesender.core.response.ResultCode;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController()
+@RequestMapping("/hello")
+public class HelloController {
+
+    @GetMapping
+    public ApiResponse<?> hello() {
+        return ApiResponse.ok("hi");
+    }
+}

--- a/src/main/java/com/knu/noticesender/core/exception/CommonExceptionHandler.java
+++ b/src/main/java/com/knu/noticesender/core/exception/CommonExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.knu.noticesender.core.exception;
+
+import com.knu.noticesender.core.response.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.servlet.http.HttpServletResponse;
+
+@RestControllerAdvice
+public class CommonExceptionHandler {
+
+    @ExceptionHandler({KnuException.class})
+    public ApiResponse<?> knuExceptionHandler(KnuException e, HttpServletResponse response) {
+        response.setStatus(e.getResultCode().getHttpStatus().value());
+        return ApiResponse.error(e);
+    }
+
+    @ExceptionHandler({RuntimeException.class})
+    public ApiResponse<?> RuntimeHandler(RuntimeException e, HttpServletResponse response) {
+        response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        return ApiResponse.error();
+    }
+}

--- a/src/main/java/com/knu/noticesender/core/exception/KnuException.java
+++ b/src/main/java/com/knu/noticesender/core/exception/KnuException.java
@@ -1,0 +1,18 @@
+package com.knu.noticesender.core.exception;
+
+import com.knu.noticesender.core.response.ResultCode;
+import lombok.Getter;
+
+@Getter
+public class KnuException extends RuntimeException{
+    private ResultCode resultCode = ResultCode.INTERNAL_SERVER_ERROR;
+
+    public KnuException(ResultCode resultCode) {
+        super();
+        this.resultCode = resultCode;
+    }
+
+    public KnuException() {
+        super();
+    }
+}

--- a/src/main/java/com/knu/noticesender/core/response/ApiResponse.java
+++ b/src/main/java/com/knu/noticesender/core/response/ApiResponse.java
@@ -1,0 +1,35 @@
+package com.knu.noticesender.core.response;
+
+import com.knu.noticesender.core.exception.KnuException;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+@Getter
+public class ApiResponse<T> implements Serializable {
+
+    private ResponseResult result;
+    private T data;
+
+    public ApiResponse(ResponseResult result, T data) {
+        this.result = result;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> ok() {
+        return new ApiResponse<>(new ResponseResult(ResultCode.SUCCESS), null);
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(new ResponseResult(ResultCode.SUCCESS), data);
+    }
+
+    public static <T> ApiResponse<T> error(KnuException e) {
+        return new ApiResponse<>(new ResponseResult(e.getResultCode()), null);
+    }
+
+    public static <T> ApiResponse<T> error() {
+        return new ApiResponse<>(new ResponseResult(ResultCode.INTERNAL_SERVER_ERROR), null);
+    }
+
+}

--- a/src/main/java/com/knu/noticesender/core/response/ResponseResult.java
+++ b/src/main/java/com/knu/noticesender/core/response/ResponseResult.java
@@ -1,0 +1,23 @@
+package com.knu.noticesender.core.response;
+
+import lombok.Getter;
+
+import java.io.Serializable;
+
+@Getter
+public class ResponseResult implements Serializable {
+    int code;
+    String message;
+
+    public ResponseResult(ResultCode resultCode) {
+        this.code = resultCode.getCode();
+        this.message = resultCode.getMessage();
+    }
+
+    public ResponseResult(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}
+
+

--- a/src/main/java/com/knu/noticesender/core/response/ResultCode.java
+++ b/src/main/java/com/knu/noticesender/core/response/ResultCode.java
@@ -1,0 +1,20 @@
+package com.knu.noticesender.core.response;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+public enum ResultCode {
+    SUCCESS(HttpStatus.OK, 200, "success"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "internal server error");
+    private HttpStatus httpStatus;
+    private int code;
+    private String message;
+
+    ResultCode(HttpStatus httpStatus, int code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/knu/noticesender/core/response/ResultCode.java
+++ b/src/main/java/com/knu/noticesender/core/response/ResultCode.java
@@ -6,8 +6,12 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ResultCode {
-    SUCCESS(HttpStatus.OK, 200, "success"),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "internal server error");
+
+    /*
+     status(3자리)_숫자(3자리)
+     */
+    SUCCESS(HttpStatus.OK, 200_001, "success"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500_001, "internal server error");
     private HttpStatus httpStatus;
     private int code;
     private String message;


### PR DESCRIPTION
## Description

클라이언트와 통신하는 기획이 추가됨에 따라 response, exception 클래스를 만들어 통일할 필요가 발생했습니다.
response, exception 핸들링을 추가했으며 changes에서 설명을 하겠습니다

## Changes

### Reseponse, RuntimeException
Response, RuntimeException 반환 같은 경우 아래와 같은 양식을 따릅니다


```json
{
    "result": {
        "code": 500001,
        "message": "internal server error"
    },
    "data": null
},

{
    "result": {
        "code": 200001,
        "message": "success"
    },
    "data": null
}
```
- code의 경우 status(3자리)순서(3자리) int 필드로 지정했습니다
- 데이터가 실릴 경우 "data"에 실리게 됩니다(객체가 실릴수도 있고 배열이 실릴 수도 있음).
- Http status는 에러, 성공에 맞게 response에 실립니다.
- 만약 response 테스트를 하고 싶다면 `/hello`에 get요청을 보내면 됩니다

## Test Checklist

- runtime exception 발생 시 반환값 확인
- 정상 response 반환 확인
